### PR TITLE
Enabling spellchecker for OCaml/Reason

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -393,6 +393,13 @@
         </intentionAction>
 
         <!--
+         | Spellchecker
+         -->
+
+        <spellchecker.support language="OCaml" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
+        <spellchecker.support language="Reason" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
+
+        <!--
          | Debug
          -->
 


### PR DESCRIPTION
Hello, again!

Would it be ok to enable spell checking inside OCaml files? I don't know much about this, I "learned" [here](https://stackoverflow.com/questions/12445117/how-to-enable-spellchecking-for-custom-language-plugins-in-idea).

According to the doc of "SpellcheckingStrategy"

> Defines spellchecking support for a custom language.
> Register via extension point com.intellij.spellchecker.support and override getTokenizer(PsiElement) to skip/handle specific elements.

As of now, this would be like this, but I would have to write more code [as he did here](https://github.com/Non-Dairy-Soy-Plugin/Non-Dairy-Soy-Plugin/tree/96176d3cc97afc97328380eae42bc3b1c9821d54/src/main/java/net/venaglia/nondairy/spellchecker) to make something better (I could look into it).

![image](https://user-images.githubusercontent.com/54904135/133306235-ca8b96f3-5ffb-4f83-890c-a12a9d76f462.png)

> **Note**: I added the line for Reason, but I don't know if this is working in Reason.