### PR TITLE
Adding Scope: Code or Comment for Live templates

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -377,7 +377,7 @@
         <defaultLiveTemplates file="liveTemplates/Reason.xml"/>
 
         <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType"/>
-        <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType$OCamlCodeTemplates"/>
+        <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType$OCamlExpressionTemplates"/>
         <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType$OCamlCommentTemplates"/>
         <defaultLiveTemplates file="liveTemplates/OCaml.xml"/>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -377,6 +377,8 @@
         <defaultLiveTemplates file="liveTemplates/Reason.xml"/>
 
         <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType"/>
+        <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType$OCamlCodeTemplates"/>
+        <liveTemplateContext implementation="com.reason.ide.template.OCamlContentType$OCamlCommentTemplates"/>
         <defaultLiveTemplates file="liveTemplates/OCaml.xml"/>
 
         <!--

--- a/resources/liveTemplates/OCaml.xml
+++ b/resources/liveTemplates/OCaml.xml
@@ -3,54 +3,54 @@
     <variable name="condition" expression="" defaultValue="&quot;condition&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="type" value="type $name$ = $value$" description="type" toReformat="false" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
     <variable name="value" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="try" value="try&#10;&#9;$code$&#10;with&#10;&#9;| _ -&gt; failwith &quot;Unknown&quot;" description="try" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="thread" value="ignore (Thread.create (fun () -&gt; &#10;    $code$&#10;  ) ())" description="create thread" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="mtype" value="module type $Name$ = sig&#10;&#9;$code$&#10;end" description="module type" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="msig" value="module $Name$ : sig&#10;&#9;$code$&#10;end" description="module signature" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="mstruct" value="module $Name$ = struct&#10;&#9;$code$&#10;end" description="module struct" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="method" value="method $name$ = $code$" description="method" toReformat="false" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="match" value="match $value$ with&#10;| $patt$ -&gt; $expr$&#10;| $_$ -&gt; $expr2$" description="match" toReformat="false" toShortenFQNames="true">
@@ -60,7 +60,7 @@
     <variable name="_" expression="" defaultValue="&quot;_&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="lin" value="let $var$ = $expr$ in $expr2$" description="let in" toReformat="false" toShortenFQNames="true">
@@ -68,14 +68,14 @@
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="fun" value="(fun $p$ -&gt; $body$)" description="fun" toReformat="false" toShortenFQNames="true">
     <variable name="p" expression="" defaultValue="&quot;()&quot;" alwaysStopAt="true" />
     <variable name="body" expression="" defaultValue="&quot;body&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="func" value="(function&#10;| $patt1$ -&gt; $expr1$&#10;| $patt2$ -&gt; $expr2$)" description="function alt" toReformat="false" toShortenFQNames="true">
@@ -84,7 +84,7 @@
     <variable name="patt2" expression="" defaultValue="&quot;patt2&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="if" value="if ($cond$) then $expr$ else $expr2$" description="if" toReformat="false" toShortenFQNames="true">
@@ -92,14 +92,14 @@
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="let" value="let $var$ = $expr$" description="let" toReformat="false" toShortenFQNames="true">
     <variable name="var" expression="" defaultValue="&quot;var(s)&quot;" alwaysStopAt="true" />
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="class" value="class $name$ =&#10;&#9;object $self$&#10;&#9;&#9;$contents$&#10;&#9;end" description="class" toReformat="false" toShortenFQNames="true">
@@ -107,13 +107,13 @@
     <variable name="self" expression="" defaultValue="&quot;(self)&quot;" alwaysStopAt="true" />
     <variable name="contents" expression="" defaultValue="&quot;contents&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="begin" value="begin&#10;&#9;$code$&#10;end" description="begin" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
   <template name="for" value="for $i$ = $startval$ to $endval$ do&#10;&#9;$code$&#10;done" description="for loop" toReformat="false" toShortenFQNames="true">
@@ -122,7 +122,7 @@
     <variable name="endval" expression="" defaultValue="&quot;endval&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="&quot;code&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML.Code" value="true" />
+      <option name="OCAML.Expression" value="true" />
     </context>
   </template>
 </templateSet>

--- a/resources/liveTemplates/OCaml.xml
+++ b/resources/liveTemplates/OCaml.xml
@@ -3,54 +3,54 @@
     <variable name="condition" expression="" defaultValue="&quot;condition&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="type" value="type $name$ = $value$" description="type" toReformat="false" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
     <variable name="value" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
-  <template name="try" value="try&#10;&#9;$code$&#10;with&#10;| _ -&gt; failwith &quot;Unknown&quot;" description="try" toReformat="false" toShortenFQNames="true">
+  <template name="try" value="try&#10;&#9;$code$&#10;with&#10;&#9;| _ -&gt; failwith &quot;Unknown&quot;" description="try" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="thread" value="ignore (Thread.create (fun () -&gt; &#10;    $code$&#10;  ) ())" description="create thread" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="mtype" value="module type $Name$ = sig&#10;&#9;$code$&#10;end" description="module type" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="msig" value="module $Name$ : sig&#10;&#9;$code$&#10;end" description="module signature" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="mstruct" value="module $Name$ = struct&#10;&#9;$code$&#10;end" description="module struct" toReformat="false" toShortenFQNames="true">
     <variable name="Name" expression="" defaultValue="&quot;Name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="method" value="method $name$ = $code$" description="method" toReformat="false" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="match" value="match $value$ with&#10;| $patt$ -&gt; $expr$&#10;| $_$ -&gt; $expr2$" description="match" toReformat="false" toShortenFQNames="true">
@@ -60,7 +60,7 @@
     <variable name="_" expression="" defaultValue="&quot;_&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="lin" value="let $var$ = $expr$ in $expr2$" description="let in" toReformat="false" toShortenFQNames="true">
@@ -68,14 +68,14 @@
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="fun" value="(fun $p$ -&gt; $body$)" description="fun" toReformat="false" toShortenFQNames="true">
     <variable name="p" expression="" defaultValue="&quot;()&quot;" alwaysStopAt="true" />
     <variable name="body" expression="" defaultValue="&quot;body&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="func" value="(function&#10;| $patt1$ -&gt; $expr1$&#10;| $patt2$ -&gt; $expr2$)" description="function alt" toReformat="false" toShortenFQNames="true">
@@ -84,7 +84,7 @@
     <variable name="patt2" expression="" defaultValue="&quot;patt2&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="if" value="if ($cond$) then $expr$ else $expr2$" description="if" toReformat="false" toShortenFQNames="true">
@@ -92,14 +92,14 @@
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <variable name="expr2" expression="" defaultValue="&quot;expr2&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="let" value="let $var$ = $expr$" description="let" toReformat="false" toShortenFQNames="true">
     <variable name="var" expression="" defaultValue="&quot;var(s)&quot;" alwaysStopAt="true" />
     <variable name="expr" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="class" value="class $name$ =&#10;&#9;object $self$&#10;&#9;&#9;$contents$&#10;&#9;end" description="class" toReformat="false" toShortenFQNames="true">
@@ -107,13 +107,13 @@
     <variable name="self" expression="" defaultValue="&quot;(self)&quot;" alwaysStopAt="true" />
     <variable name="contents" expression="" defaultValue="&quot;contents&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="begin" value="begin&#10;&#9;$code$&#10;end" description="begin" toReformat="false" toShortenFQNames="true">
     <variable name="code" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
   <template name="for" value="for $i$ = $startval$ to $endval$ do&#10;&#9;$code$&#10;done" description="for loop" toReformat="false" toShortenFQNames="true">
@@ -122,7 +122,7 @@
     <variable name="endval" expression="" defaultValue="&quot;endval&quot;" alwaysStopAt="true" />
     <variable name="code" expression="" defaultValue="&quot;code&quot;" alwaysStopAt="true" />
     <context>
-      <option name="OCAML" value="true" />
+      <option name="OCAML.Code" value="true" />
     </context>
   </template>
 </templateSet>

--- a/src/com/reason/ide/template/OCamlContentType.java
+++ b/src/com/reason/ide/template/OCamlContentType.java
@@ -27,9 +27,9 @@ public class OCamlContentType extends TemplateContextType {
     }
 
     // Code-only
-    private static final class OCamlCodeTemplates extends ScopeTemplates {
-        public OCamlCodeTemplates() {
-            super("Code", false);
+    private static final class OCamlExpressionTemplates extends ScopeTemplates {
+        public OCamlExpressionTemplates() {
+            super("Expression", false);
         }
     }
     // Comments only
@@ -40,11 +40,16 @@ public class OCamlContentType extends TemplateContextType {
     }
 
     private static class ScopeTemplates extends OCamlContentType {
-        private final boolean comments;
+        private final boolean myOnComment;
 
-        protected ScopeTemplates(String name, boolean comments) {
+        /**
+         * @param name name of the scope, capitalized
+         * @param onComment if true, then "isContext" is checking that we are inside a Comment,
+         *                 otherwise, "isContext" is checking that we aren't inside a Comment
+         */
+        protected ScopeTemplates(String name, boolean onComment) {
             super(name);
-            this.comments = comments;
+            myOnComment = onComment;
         }
 
         @Override
@@ -60,7 +65,7 @@ public class OCamlContentType extends TemplateContextType {
             }
 
             PsiElement element = file.findElementAt(offset);
-            return this.comments == (element instanceof PsiComment);
+            return myOnComment == (element instanceof PsiComment);
         }
     }
 }

--- a/src/com/reason/ide/template/OCamlContentType.java
+++ b/src/com/reason/ide/template/OCamlContentType.java
@@ -2,6 +2,9 @@ package com.reason.ide.template;
 
 import com.intellij.codeInsight.template.TemplateActionContext;
 import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.*;
+import com.intellij.psi.util.*;
+import com.reason.lang.ocaml.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -13,9 +16,51 @@ public class OCamlContentType extends TemplateContextType {
         super("OCAML", "Ocaml");
     }
 
+    protected OCamlContentType(String name) {
+        super("OCAML."+name, name, OCamlContentType.class);
+    }
+
     @Override
     public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
         final String name = templateActionContext.getFile().getName();
         return name.endsWith(".ml") || name.endsWith(".mli");
+    }
+
+    // Code-only
+    private static final class OCamlCodeTemplates extends ScopeTemplates {
+        public OCamlCodeTemplates() {
+            super("Code", false);
+        }
+    }
+    // Comments only
+    private static final class OCamlCommentTemplates extends ScopeTemplates {
+        public OCamlCommentTemplates() {
+            super("Comment", true);
+        }
+    }
+
+    private static class ScopeTemplates extends OCamlContentType {
+        private final boolean comments;
+
+        protected ScopeTemplates(String name, boolean comments) {
+            super(name);
+            this.comments = comments;
+        }
+
+        @Override
+        public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+            if(!super.isInContext(templateActionContext)) return false;
+
+            // RmlContextType - copy of the 6 following lines
+            // with RmlLanguage => OclLanguage
+            PsiFile file = templateActionContext.getFile();
+            int offset = templateActionContext.getStartOffset();
+            if (!PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(OclLanguage.INSTANCE)) {
+                return false;
+            }
+
+            PsiElement element = file.findElementAt(offset);
+            return this.comments == (element instanceof PsiComment);
+        }
     }
 }


### PR DESCRIPTION
Hello, I added scopes for live templates (code/comment). Every live template is now disabled inside comments, so that we can write if/while/... without getting weird suggestions.

Inside the settings of our Live templates, we have

![Screenshot_3](https://user-images.githubusercontent.com/54904135/133321524-aa42514c-d5a7-408b-8f5d-6a9b2f9cc08c.png)
