### PR TITLE
Spell checker

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -398,9 +398,9 @@
          | Spellchecker
          -->
 
-        <spellchecker.support language="OCaml" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
-        <spellchecker.support language="Reason" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
-        <spellchecker.support language="Rescript" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
+        <spellchecker.support language="OCaml" implementationClass="com.reason.ide.spellcheckers.OCamlSpellCheckerStrategy"/>
+        <spellchecker.support language="Reason" implementationClass="com.reason.ide.spellcheckers.ReasonSpellCheckerStrategy"/>
+        <spellchecker.support language="Rescript" implementationClass="com.reason.ide.spellcheckers.CustomSpellCheckerStrategy"/>
 
         <!--
          | Debug

--- a/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
+++ b/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
@@ -1,0 +1,49 @@
+package com.reason.ide.spellcheckers;
+
+import com.intellij.lang.injection.*;
+import com.intellij.psi.*;
+import com.intellij.spellchecker.tokenizer.*;
+import com.reason.lang.core.psi.PsiLiteralExpression;
+import com.reason.lang.core.psi.impl.*;
+import org.jetbrains.annotations.*;
+
+/**
+ * Handling the Generic SpellcheckingStrategy
+ *
+ * @see SpellcheckingStrategy
+ * @see OCamlSpellCheckerStrategy
+ */
+public class CustomSpellCheckerStrategy extends SpellcheckingStrategy {
+
+    @Override public @NotNull Tokenizer<?> getTokenizer(PsiElement element) {
+        if (element instanceof PsiWhiteSpace) { // skip whitespace
+            return EMPTY_TOKENIZER;
+        }
+        // skip other languages
+        if (element instanceof PsiLanguageInjectionHost &&
+                InjectedLanguageManager.getInstance(element.getProject()).getInjectedPsiFiles(element) != null) {
+            return EMPTY_TOKENIZER;
+        }
+        // handle comments
+        if (element instanceof PsiComment) {
+            return myCommentTokenizer;
+        }
+        // literals
+        if (element instanceof PsiLiteralExpression) {
+            return TEXT_TOKENIZER;
+        }
+        // named elements
+        if (element instanceof PsiNameIdentifierOwner) {
+            // not allowed
+            if (element instanceof PsiAnnotationImpl) {
+                return EMPTY_TOKENIZER;
+            }
+            return PsiIdentifierOwnerTokenizer.INSTANCE;
+        }
+        // Type (type name = TypeBinding)
+        if (element instanceof PsiTypeBinding) {
+            return TEXT_TOKENIZER;
+        }
+        return EMPTY_TOKENIZER; // skip everything else
+    }
+}

--- a/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
+++ b/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
@@ -2,6 +2,7 @@ package com.reason.ide.spellcheckers;
 
 import com.intellij.lang.injection.*;
 import com.intellij.psi.*;
+import com.intellij.psi.impl.source.tree.*;
 import com.intellij.spellchecker.tokenizer.*;
 import com.reason.lang.core.psi.PsiLiteralExpression;
 import com.reason.lang.core.psi.impl.*;
@@ -17,6 +18,10 @@ public class CustomSpellCheckerStrategy extends SpellcheckingStrategy {
 
     @Override public @NotNull Tokenizer<?> getTokenizer(PsiElement element) {
         if (element instanceof PsiWhiteSpace) { // skip whitespace
+            return EMPTY_TOKENIZER;
+        }
+        // optimization
+        if (element.getClass() == LeafPsiElement.class) {
             return EMPTY_TOKENIZER;
         }
         // skip other languages
@@ -35,13 +40,13 @@ public class CustomSpellCheckerStrategy extends SpellcheckingStrategy {
         // named elements
         if (element instanceof PsiNameIdentifierOwner) {
             // not allowed
-            if (element instanceof PsiAnnotationImpl) {
+            if (element instanceof PsiAnnotationImpl || element instanceof PsiMacroName) {
                 return EMPTY_TOKENIZER;
             }
             return PsiIdentifierOwnerTokenizer.INSTANCE;
         }
         // Type (type name = TypeBinding)
-        if (element instanceof PsiTypeBinding) {
+        if (element instanceof PsiTypeBinding || element instanceof PsiLowerSymbolImpl) {
             return TEXT_TOKENIZER;
         }
         return EMPTY_TOKENIZER; // skip everything else

--- a/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
+++ b/src/com/reason/ide/spellcheckers/CustomSpellCheckerStrategy.java
@@ -45,8 +45,8 @@ public class CustomSpellCheckerStrategy extends SpellcheckingStrategy {
             }
             return PsiIdentifierOwnerTokenizer.INSTANCE;
         }
-        // Type (type name = TypeBinding)
-        if (element instanceof PsiTypeBinding || element instanceof PsiLowerSymbolImpl) {
+        // ... = PsiLowerSymbolImpl
+        if (element instanceof PsiLowerSymbolImpl) {
             return TEXT_TOKENIZER;
         }
         return EMPTY_TOKENIZER; // skip everything else

--- a/src/com/reason/ide/spellcheckers/OCamlSpellCheckerStrategy.java
+++ b/src/com/reason/ide/spellcheckers/OCamlSpellCheckerStrategy.java
@@ -1,0 +1,12 @@
+package com.reason.ide.spellcheckers;
+
+import com.intellij.psi.*;
+import com.intellij.spellchecker.tokenizer.*;
+import org.jetbrains.annotations.*;
+
+public class OCamlSpellCheckerStrategy extends CustomSpellCheckerStrategy {
+
+    @Override public @NotNull Tokenizer<?> getTokenizer(PsiElement element) {
+        return super.getTokenizer(element);
+    }
+}

--- a/src/com/reason/ide/spellcheckers/ReasonSpellCheckerStrategy.java
+++ b/src/com/reason/ide/spellcheckers/ReasonSpellCheckerStrategy.java
@@ -1,0 +1,12 @@
+package com.reason.ide.spellcheckers;
+
+import com.intellij.psi.*;
+import com.intellij.spellchecker.tokenizer.*;
+import org.jetbrains.annotations.*;
+
+public class ReasonSpellCheckerStrategy extends CustomSpellCheckerStrategy {
+
+    @Override public @NotNull Tokenizer<?> getTokenizer(PsiElement element) {
+        return super.getTokenizer(element);
+    }
+}

--- a/src/com/reason/ide/template/OCamlContentType.java
+++ b/src/com/reason/ide/template/OCamlContentType.java
@@ -2,9 +2,9 @@ package com.reason.ide.template;
 
 import com.intellij.codeInsight.template.*;
 import com.intellij.psi.*;
-import com.intellij.psi.util.PsiUtilCore;
-import com.reason.lang.ocaml.OclLanguage;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.psi.util.*;
+import com.reason.lang.ocaml.*;
+import org.jetbrains.annotations.*;
 
 /**
  * Every "*.ml" kind of file is considered to be a part of the OCaml context

--- a/src/com/reason/ide/template/OCamlContentType.java
+++ b/src/com/reason/ide/template/OCamlContentType.java
@@ -1,10 +1,9 @@
 package com.reason.ide.template;
 
-import com.intellij.codeInsight.template.TemplateActionContext;
-import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.codeInsight.template.*;
 import com.intellij.psi.*;
-import com.intellij.psi.util.*;
-import com.reason.lang.ocaml.*;
+import com.intellij.psi.util.PsiUtilCore;
+import com.reason.lang.ocaml.OclLanguage;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -17,11 +16,10 @@ public class OCamlContentType extends TemplateContextType {
     }
 
     protected OCamlContentType(String name) {
-        super("OCAML."+name, name, OCamlContentType.class);
+        super("OCAML." + name, name, OCamlContentType.class);
     }
 
-    @Override
-    public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+    @Override public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
         final String name = templateActionContext.getFile().getName();
         return name.endsWith(".ml") || name.endsWith(".mli");
     }
@@ -32,6 +30,7 @@ public class OCamlContentType extends TemplateContextType {
             super("Expression", false);
         }
     }
+
     // Comments only
     private static final class OCamlCommentTemplates extends ScopeTemplates {
         public OCamlCommentTemplates() {
@@ -43,18 +42,19 @@ public class OCamlContentType extends TemplateContextType {
         private final boolean myOnComment;
 
         /**
-         * @param name name of the scope, capitalized
+         * @param name      name of the scope, capitalized
          * @param onComment if true, then "isContext" is checking that we are inside a Comment,
-         *                 otherwise, "isContext" is checking that we aren't inside a Comment
+         *                  otherwise, "isContext" is checking that we aren't inside a Comment
          */
         protected ScopeTemplates(String name, boolean onComment) {
             super(name);
             myOnComment = onComment;
         }
 
-        @Override
-        public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
-            if(!super.isInContext(templateActionContext)) return false;
+        @Override public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+            if (!super.isInContext(templateActionContext)) {
+                return false;
+            }
 
             // RmlContextType - copy of the 6 following lines
             // with RmlLanguage => OclLanguage


### PR DESCRIPTION
#344: I only allowed some elements, instead of allowing spell checking everywhere and disabling them one by one.

![image](https://user-images.githubusercontent.com/54904135/133439791-09ed5570-152e-4619-afae-265a261b451c.png)

But, I don't know why this is not working everytime (**edit**: this is because this I had `type name = value [@@something]` and `value [@@something]` is considered as a `PsiTypeBinding`. I would have to do more work to patch this, but I think this is a waste of time as the initial problem is solved)

![image](https://user-images.githubusercontent.com/54904135/133439914-d179d973-1968-435f-b492-fa9142407ad5.png)