### PR TITLE
Type inference

### DIFF
--- a/src/com/reason/hints/InsightManagerImpl.java
+++ b/src/com/reason/hints/InsightManagerImpl.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.*;
 import com.intellij.openapi.vfs.*;
 import com.reason.comp.Compiler;
 import com.reason.comp.*;
+import com.reason.ide.settings.*;
 import jpsplugin.com.reason.*;
 import org.jetbrains.annotations.*;
 
@@ -105,6 +106,13 @@ public class InsightManagerImpl implements InsightManager {
 
         if (ocamlVersion != null && !rincewindVersion.equals(excludedVersion)) {
             return "rincewind_" + getOsPrefix() + ocamlVersion + "-" + rincewindVersion + ".exe";
+        } else if (ocamlVersion == null){
+            ORSettings settings = myProject.getService(ORSettings.class);
+            ocamlVersion = settings.getOcamlFallback();
+            if (ocamlVersion != null){
+                rincewindVersion = getRincewindVersion(ocamlVersion);
+                return "rincewind_" + getOsPrefix() + ocamlVersion + "-" + rincewindVersion + ".exe";
+            }
         }
 
         return null;

--- a/src/com/reason/hints/RincewindProcess.java
+++ b/src/com/reason/hints/RincewindProcess.java
@@ -26,7 +26,7 @@ public class RincewindProcess {
         LOG.debug("Looking for types for file", sourceFile);
 
         Optional<VirtualFile> contentRoot = BsPlatform.findContentRoot(myProject, sourceFile);
-        if (!contentRoot.isPresent()) {
+        if (contentRoot.isEmpty()) {
             return;
         }
 

--- a/src/com/reason/ide/settings/ORSettings.java
+++ b/src/com/reason/ide/settings/ORSettings.java
@@ -9,6 +9,9 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
     private static final boolean IS_FORMAT_ON_SAVE_DEFAULT = true;
     private static final String FORMAT_WIDTH_COLUMNS_DEFAULT = "80";
     private static final boolean IS_BS_ENABLED_DEFAULT = true;
+    private static final String[] RINCEWIND_SUPPORTED_VERSIONS = new String[]{
+            "", "4.06.1", "4.07.1", "4.08.1", "4.09.1", "4.10.0"
+    };
 
     private final @NotNull Project m_project;
 
@@ -16,6 +19,7 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
     private boolean m_isFormatOnSaveEnabled = IS_FORMAT_ON_SAVE_DEFAULT;
     private @Nullable String m_formatColumnWidth;
     private boolean myUseSuperErrors = false;
+    private String myOcamlFallback = "";
 
     // BuckleScript
     private boolean m_isBsEnabled = IS_BS_ENABLED_DEFAULT;
@@ -38,6 +42,7 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
         state.isBsEnabled = m_isBsEnabled;
         state.bsPlatformLocation = m_bsPlatformLocation;
         state.esyExecutable = m_esyExecutable;
+        state.myOcamlFallback = myOcamlFallback;
         return state;
     }
 
@@ -49,6 +54,7 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
         m_isBsEnabled = state.isBsEnabled;
         m_bsPlatformLocation = state.bsPlatformLocation;
         m_esyExecutable = state.esyExecutable;
+        myOcamlFallback = state.myOcamlFallback;
     }
 
     public @NotNull Project getProject() {
@@ -86,6 +92,18 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
         myUseSuperErrors = useSuperErrors;
     }
 
+    public String getOcamlFallback() {
+        return myOcamlFallback.equals("") ? null : myOcamlFallback;
+    }
+
+    public void setOcamlFallback(String ocamlFallback) {
+        myOcamlFallback = ocamlFallback;
+    }
+
+    public String[] getOcamlFallbacks() {
+        return RINCEWIND_SUPPORTED_VERSIONS;
+    }
+
     public boolean isBsEnabled() {
         return m_isBsEnabled;
     }
@@ -115,6 +133,7 @@ public class ORSettings implements PersistentStateComponent<ORSettings.ReasonSet
         // General
         public boolean isFormatOnSaveEnabled = IS_FORMAT_ON_SAVE_DEFAULT;
         public @Nullable String formatColumnWidth;
+        public String myOcamlFallback;
         public boolean isUseSuperErrors = false;
         // BuckleScript
         public boolean isBsEnabled = IS_BS_ENABLED_DEFAULT;

--- a/src/com/reason/ide/settings/ORSettingsConfigurable.form
+++ b/src/com/reason/ide/settings/ORSettingsConfigurable.form
@@ -129,7 +129,7 @@
                         </constraints>
                         <properties>
                           <labelFor value="42670"/>
-                          <text value="If you didn't set OCaml SDK, you may set OCaml version here to enable Type inference"/>
+                          <text value="If you aren't using a build tool, you may set the version of OCaml here to enable Type inference"/>
                         </properties>
                       </component>
                       <component id="42670" class="javax.swing.JComboBox" binding="f_setOCamlFallBack">

--- a/src/com/reason/ide/settings/ORSettingsConfigurable.form
+++ b/src/com/reason/ide/settings/ORSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="f_rootPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="823" height="400"/>
+      <xy x="20" y="20" width="823" height="410"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -25,7 +25,7 @@
             </properties>
             <border type="etched"/>
             <children>
-              <grid id="5a7f7" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="5a7f7" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="10" left="10" bottom="10" right="10"/>
                 <constraints>
                   <tabbedpane title="General"/>
@@ -36,7 +36,7 @@
                   <grid id="d2465" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="10" left="10" bottom="10" right="10"/>
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <name value="refmt"/>
@@ -95,7 +95,7 @@
                   <grid id="cdaf5" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="10" left="10" bottom="10" right="10"/>
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                     <border type="etched" title="Compiler"/>
@@ -115,9 +115,34 @@
                       </hspacer>
                     </children>
                   </grid>
-                  <vspacer id="c5e73">
+                  <grid id="45941" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="10" left="10" bottom="10" right="10"/>
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="etched" title="OCaml"/>
+                    <children>
+                      <component id="7b4a" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <labelFor value="42670"/>
+                          <text value="If you didn't set OCaml SDK, you may set OCaml version here to enable Type inference"/>
+                        </properties>
+                      </component>
+                      <component id="42670" class="javax.swing.JComboBox" binding="f_setOCamlFallBack">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                      </component>
+                    </children>
+                  </grid>
+                  <vspacer id="a061">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </vspacer>
                 </children>

--- a/src/com/reason/ide/settings/ORSettingsConfigurable.java
+++ b/src/com/reason/ide/settings/ORSettingsConfigurable.java
@@ -25,6 +25,7 @@ public class ORSettingsConfigurable implements SearchableConfigurable, Configura
     private JTextField f_generalFormatWidthColumns;
     private JCheckBox f_generalIsFormatOnSave;
     private JCheckBox myUseSuperErrorsCheckBox;
+    private JComboBox<String> f_setOCamlFallBack;
 
     // BuckleScript
     private JCheckBox f_bsIsEnabled;
@@ -73,6 +74,7 @@ public class ORSettingsConfigurable implements SearchableConfigurable, Configura
         m_settings.setFormatOnSaveEnabled(f_generalIsFormatOnSave.isSelected());
         m_settings.setFormatColumnWidth(sanitizeInput(f_generalFormatWidthColumns));
         m_settings.setUseSuperErrors(myUseSuperErrorsCheckBox.isSelected());
+        m_settings.setOcamlFallback((String) f_setOCamlFallBack.getSelectedItem());
         // BuckleScript
         m_settings.setBsEnabled(f_bsIsEnabled.isSelected());
         m_settings.setBsPlatformLocation(sanitizeInput(f_bsPlatformLocation));
@@ -92,12 +94,17 @@ public class ORSettingsConfigurable implements SearchableConfigurable, Configura
                 !f_bsPlatformLocation.getText().equals(m_settings.getBsPlatformLocation());
         boolean isEsyExecutableModified =
                 !f_esyExecutable.getText().equals(m_settings.getEsyExecutable());
+
+        String selectedItem = (String) f_setOCamlFallBack.getSelectedItem();
+        boolean isOCamlFallbackModified =
+                selectedItem != null && !selectedItem.equals(m_settings.getOcamlFallback());
         return isFormatOnSaveModified
                 || isFormatWidthColumnsModified
                 || isUseSuperErrorModified
                 || isBsEnabledModified
                 || isBsPlatformLocationModified
-                || isEsyExecutableModified;
+                || isEsyExecutableModified
+                || isOCamlFallbackModified;
     }
 
     @Override
@@ -106,6 +113,7 @@ public class ORSettingsConfigurable implements SearchableConfigurable, Configura
         f_generalIsFormatOnSave.setSelected(m_settings.isFormatOnSaveEnabled());
         f_generalFormatWidthColumns.setText(m_settings.getFormatColumnWidth());
         myUseSuperErrorsCheckBox.setSelected(m_settings.isUseSuperErrors());
+        f_setOCamlFallBack.setSelectedItem(m_settings.getOcamlFallback());
         // BuckleScript
         f_bsIsEnabled.setSelected(m_settings.isBsEnabled());
         f_bsPlatformLocation.setText(m_settings.getBsPlatformLocation());
@@ -114,6 +122,10 @@ public class ORSettingsConfigurable implements SearchableConfigurable, Configura
     }
 
     private void createGeneralTab() {
+        for (String ocamlVersion:m_settings.getOcamlFallbacks()) {
+            f_setOCamlFallBack.addItem(ocamlVersion);
+        }
+        f_setOCamlFallBack.setSelectedIndex(0);
     }
 
     private void createBsTab() {


### PR DESCRIPTION
Hello, again!

>  It is downloaded automatically by the plugin when the corresponding OCaml version is known.

If we are compiling files manually (either with ocamlc or a Makefile+ocamlc), the type inference is not available (as this is not one of the supported tools). I added something in the Settings allowing the user to pick the version of OCaml

![image](https://user-images.githubusercontent.com/54904135/133473571-8910081b-6f8f-4a7c-a74f-0c3f3a971265.png)

Sorry for the bunch of pull requests 🙇‍♂️, I'm almost done (I think?)
